### PR TITLE
Clean up spelling and formatting of documents in this repo

### DIFF
--- a/SoftwareArchitectureDocument.md
+++ b/SoftwareArchitectureDocument.md
@@ -2,68 +2,86 @@
 
 ## 1. Introduction
 
-### 1.1	Purpose
+### 1.1 Purpose
+
 This document provides a comprehensive architectural overview of the system, using a number of different architectural views to depict different aspects of the system. It is intended to capture and convey the significant architectural decisions which have been made on the system.
 
-### 1.2	Scope
-This document is closely related to the Software Requirement Specifications and it's defined Use Cases. You can find both in the GitHub repository of this Project (See 1.4: References). 
- 
-### 1.3	Definitions, Acronyms, and Abbreviations
-*  MVC = Model View Controller
-*  N.a = Not applicable / Not available
+### 1.2 Scope
 
-### 1.4	References
-*  [Github Repository](https://github.com/tomorow94/GardeningPlaner)
+This document is closely related to the Software Requirement Specifications and it's defined Use Cases. You can find both in the GitHub repository of this Project (See 1.4: References).
 
-### 1.5	Overview
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+* MVC = Model View Controller
+* N.a = Not applicable / Not available
+
+### 1.4 References
+
+* [Github Repository](https://github.com/tomorow94/GardeningPlaner)
+
+### 1.5 Overview
+
 This Document contains information about the software architecture. In more details, you can find information about Architectural Representation, Architectural Goals and Constraints, Use-Case View,
 Logical View, Process View, Deployment View, Implementation View, Data View, Size and Performance and Quality.
 
 ### 1.6 Tech Stack
-*  Java ver. 1.8
-*  JUnit ver. 4.12
-*  Android ver. 28.0.0
-*  AndroidStudio ver. 3.4.2
-*  Graddle ver. 3.4.2
-*  GitHub
+
+* Java ver. 1.8
+* JUnit ver. 4.12
+* Android ver. 28.0.0
+* AndroidStudio ver. 3.4.2
+* Gradle ver. 3.4.2
+* GitHub
 
 ## 2. Architectural Representation
+
 This section describes what software architecture is for the current system.
 The application was built after the MVC architecture.
 
 ## 3. Architectural Goals and Constraints
+
 N.a
 
 ## 4. Use-Case View
+
 N.a
 
 ## 5. Logical View
 
 ### 5.1 Overview
+
 N.a
 
-### 5.2	Architecturally Significant Design Packages
+### 5.2 Architecturally Significant Design Packages
+
 N.a
 
-## 6. Process View 
+## 6. Process View
+
 N.a
 
-## 7. Deployment View 
+## 7. Deployment View
+
 N.a
 
-## 8. Implementation View 
+## 8. Implementation View
 
 ### 8.1 Overview
+
 N.a
 
 ### 8.2 Layers
+
 N.a
 
 ## 9. Data View
+
 N.a
 
 ## 10. Size and Performance
+
 N.a
 
 ## 11. Quality
+
 N.a

--- a/SoftwareRequirementsSpecification.md
+++ b/SoftwareRequirementsSpecification.md
@@ -12,20 +12,20 @@ This SRS describes the Android Application “Gardening Planer”. It contains a
 
 ## <a name="1.2 Scope">1.2 Scope</a>
 
-“Gardening Planer” will be an AndoidApp used to plan your crops you plant in your bed - expecially in view of the 3 year use of topsoil in high beds
+“Gardening Planer” will be an AndroidApp used to plan your crops you plant in your bed - especially in view of the 3 year use of topsoil in high beds
 
 ## <a name="1.3 Definitions, Acronyms and Abbreviations">1.3 Definitions, Acronyms and Abbreviations</a>
 
 n/a: Not Applicable
-<br/>Play Store: Google Play Store 
+<br/>Play Store: Google Play Store
 <br/>tbd: to be determined
 
 ## <a name="1.4 References">1.4 References</a>
 
 [Android Studio](https://developer.android.com/studio/)
-<br/>[GIT](https://git-scm.com/)
-<br/>[GitHub](https://github.com/)
-<br/>[Google Play Store](https://play.google.com/store)
+[GIT](https://git-scm.com/)
+[GitHub](https://github.com/)
+[Google Play Store](https://play.google.com/store)
 
 ## <a name="1.5 Overview">1.5 Overview</a>
 
@@ -37,7 +37,7 @@ The following Chapters describe the vision for the project, the requirements for
 "Gardening Planer" will be an App that helps you to find crops that befitt eachother or at least dont hinder other crops in your bed. In addition the nutrition requirements of the different crops, the depth of the roots and the space the plant will need in grown state will be considered to optimize your yield. The then developed plan for your garden can be saved and can be viewed again and again.
 
 # <a name="2.1 Software">2.2 Software</a>
-"Gardening Planer" will be developed in Java as an application that can run on Android. 
+"Gardening Planer" will be developed in Java as an application that can run on Android.
 
 # <a name="3. Specific Requirements">3. Specific Requirements</a>
 

--- a/testPlan.md
+++ b/testPlan.md
@@ -1,169 +1,298 @@
 # Test plan
 
-## 1.	Introduction
-### 1.1	Purpose
-The purpose of the Iteration Test Plan is to gather all of the information necessary to plan and control the test effort for a given iteration. 
+## 1.   Introduction
+
+### 1.1 Purpose
+
+The purpose of the Iteration Test Plan is to gather all of the information necessary to plan and control the test effort for a given iteration.
 It describes the approach to testing the software.
 This Test Plan for vnv supports the following objectives:
--	Identifies the items that should be targeted by the tests.
--	Identifies the motivation for and ideas behind the test areas to be covered.
--	Outlines the testing approach that will be used.
--	Identifies the required resources and provides an estimate of the test efforts.
-### 1.2	Scope
+
+- Identifies the items that should be targeted by the tests.
+- Identifies the motivation for and ideas behind the test areas to be covered.
+- Outlines the testing approach that will be used.
+- Identifies the required resources and provides an estimate of the test efforts.
+
+### 1.2 Scope
+
 This document describes the used tests, as they are unittests and functionality testing.
-### 1.3	Intended Audience
+
+### 1.3 Intended Audience
+
 This document is meant for internal use primarily.
-### 1.4	Document Terminology and Acronyms
-- **SRS**	Software Requirements Specification
-- **n/a**	not applicable
-- **tbd**	to be determined
-### 1.5	 References
+
+### 1.4 Document Terminology and Acronyms
+
+- **SRS** Software Requirements Specification
+- **n/a** not applicable
+- **tbd** to be determined
+
+### 1.5 References
+
 - [GitHub](https://github.com/tomorow94/GardeningPlaner)
 - [SRS](https://github.com/tomorow94/GardeningPlaner/blob/master/SoftwareRequirementsSpecification.md)
 
 ### 1.6 Document Structure
+
 tbd
-## 2.	Evaluation Mission and Test Motivation
-### 2.1	Background
+
+## 2. Evaluation Mission and Test Motivation
+
+### 2.1 Background
+
 By testing our project, we make sure that all changes to the sourcecode do not break the functionality. Also by integrating the test process in our deployment process, we make sure that only working versions of our project getting deployed. So the web application is always available.
-### 2.2	Evaluation Mission
+
+### 2.2 Evaluation Mission
+
 Our motivation in implementing tests came at an early stage to recognize the need for errors and to ensure the functionality and thus the outstanding quality of the software.
-### 2.3	Test Motivators
+
+### 2.3 Test Motivators
+
 Our motivation in implementing tests came at an early stage to recognize the need for errors and to ensure the functionality and thus the outstanding quality of the software.
-Our testing is motivated by 
-- quality risks 
-- technical risks, 
-- use cases 
+Our testing is motivated by
+
+- quality risks
+- technical risks,
+- use cases
 - functional requirements
-## 3.	Target Test Items
-The listing below identifies those test items (software, hardware, and supporting product elements) that have been identified as targets for testing. This list represents what items will be tested. 
+
+## 3. Target Test Items
+
+The listing below identifies those test items (software, hardware, and supporting product elements) that have been identified as targets for testing. This list represents what items will be tested.
 Items for Testing:
+
 - java backend
 - UI (Android-App)
 - local installation
-## 4.	Outline of Planned Tests
-### 4.1	Outline of Test Inclusions
-Unit testing of the java backend and functional testing of the user-interface aswell as a installationtest from a user.
-### 4.2	Outline of Other Candidates for Potential Inclusion
-Integrationtesting of key elements that work on a wider scope are potential test szenarios aswell but these are not in scope if our current testing process.
+
+## 4. Outline of Planned Tests
+
+### 4.1 Outline of Test Inclusions
+
+Unit testing of the java backend and functional testing of the user-interface as well as a installation test from a user.
+
+### 4.2 Outline of Other Candidates for Potential Inclusion
+
+Integration testing of key elements that work on a wider scope are potential test scenarios as well but these are not in scope if our current testing process.
+
 ### 4.3 Outline of Test Exclusion
+
 tbd
-## 5.	Test Approach
-### 5.1 Initial Test-Idea Catalogs and other Rference Sources
-### 5.2	Testing Techniques and Types
-#### 5.2.1	Function and Database Integrity Testing
+
+## 5. Test Approach
+
+### 5.1 Initial Test-Idea Catalogs and other Reference Sources
+
+### 5.2 Testing Techniques and Types
+
+#### 5.2.1 Function and Database Integrity Testing
+
 n/a
-#### 5.2.2	Unit Testing
+
+#### 5.2.2 Unit Testing
+
 || |
 |---|---|
-|Technique Objective  	| Exercise functionality of model functions. Test for right data entry and right data output. |
-|Technique 		|  Execute JUnit Test functions in our test classes |
-|Oracles 		|  Each test expect the right value given in the assertequals function |
-|Required Tools 	|  JUnit Test |
-|Success Criteria	|    Testcoverage > ?%      |
-|Special Considerations	|     -          |
-#### 5.2.3	Business Cycle Testing
+|Technique Objective   | Exercise functionality of model functions. Test for right data entry and right data output. |
+|Technique   |  Execute JUnit Test functions in our test classes |
+|Oracles   |  Each test expect the right value given in the assertequals function |
+|Required Tools  |  JUnit Test |
+|Success Criteria |    Test coverage > ?%      |
+|Special Considerations |     -          |
+
+#### 5.2.3 Business Cycle Testing
+
 n/a
-#### 5.2.4	User Interface Testing
+
+#### 5.2.4 User Interface Testing
+
 Automated with use of Cucumber and Feature-Files
-#### 5.2.5	Performance Profiling 
+
+#### 5.2.5 Performance Profiling
+
 n/a
-#### 5.2.6	Load Testing
+
+#### 5.2.6 Load Testing
+
 n/a
-#### 5.2.7	Stress Testing
+
+#### 5.2.7 Stress Testing
+
 n/a
-#### 5.2.8	Volume Testing
+
+#### 5.2.8 Volume Testing
+
 n/a
-#### 5.2.9	Security and Access Control Testing
+
+#### 5.2.9 Security and Access Control Testing
+
 n/a
-#### 5.2.10	Failover and Recovery Testing
+
+#### 5.2.10 Failover and Recovery Testing
+
 n/a
-#### 5.2.11	Configuration Testing
+
+#### 5.2.11 Configuration Testing
+
 n/a
-#### 5.2.12	Installation Testing
+
+#### 5.2.12 Installation Testing
+
 n/a
+
 #### 5.2.13 User Acceptance Testing
+
 UAT as so called pre-Alpha-Tests with a few users testing the game in the current state to play it before release and give constructive feedback.
 
-## 6.	Entry and Exit Criteria
-### 6.1	Test Plan
-#### 6.1.1	Test Plan Entry Criteria
+## 6. Entry and Exit Criteria
+
+### 6.1 Test Plan
+
+#### 6.1.1 Test Plan Entry Criteria
+
 Building a new version of the software will execute the testprocess.
-#### 6.1.2	Test Plan Exit Criteria
+
+#### 6.1.2 Test Plan Exit Criteria
+
 When all tests pass without throwing an exception.
+
 #### 6.1.3 Suspension and Resumption Criteria
+
 n/a
+
 ### 6.2 Test Cycles
-#### 6.2.1 Test Cycle Entry Critria
+
+#### 6.2.1 Test Cycle Entry Criteria
+
 n/a
+
 #### 6.2.2 Test Cycle Exit Criteria
+
 n/a
+
 #### 6.2.3 Test Cycle Abnormal Termination
+
 n/a
-## 7.	Deliverables
-### 7.1	Test Evaluation Summaries
+
+## 7. Deliverables
+
+### 7.1 Test Evaluation Summaries
+
 n/a
-### 7.2	Reporting on Test Coverage
+
+### 7.2 Reporting on Test Coverage
+
 n/a
-### 7.3	Perceived Quality Reports
+
+### 7.3 Perceived Quality Reports
+
 n/a
-### 7.4	Incident Logs and Change Requests
+
+### 7.4 Incident Logs and Change Requests
+
 n/a
-### 7.5	Smoke Test Suite and Supporting Test Scripts
+
+### 7.5 Smoke Test Suite and Supporting Test Scripts
+
 n/a
-### 7.6	Additional Work Products
+
+### 7.6 Additional Work Products
+
 n/a
-#### 7.6.1	Detailed Test Results
+
+#### 7.6.1 Detailed Test Results
+
 n/a
-#### 7.6.2	Additional Automated Functional Test Scripts
+
+#### 7.6.2 Additional Automated Functional Test Scripts
+
 n/a
-#### 7.6.3	Test Guidelines
+
+#### 7.6.3 Test Guidelines
+
 - One test-class contains test for only one class that needs to be tested
 - The test-class should have the same name as the class to be tested with the Addition "Test" at the end (ex. MyClass -> MyClassTest)
 - The test-functions should be named so one can see its purpose without the need of looking into the implementation. It should contain the name of the tested function, the testcase and the expected outcome. (ex. "setSpeed_canNotBeNegative_speedShouldBeUnchanged()").
-#### 7.6.4	Traceability Matrices
+
+#### 7.6.4 Traceability Matrices
+
 n/a
-## 8.	Testing Workflow
+
+## 8. Testing Workflow
+
 n/a
-## 9.	Environmental Needs
+
+## 9. Environmental Needs
+
 This section presents the non-human resources required for the Test Plan.
-### 9.1	Base System Hardware
+
+### 9.1 Base System Hardware
+
 tbd
-### 9.2	Base Software Elements in the Test Environment
+
+### 9.2 Base Software Elements in the Test Environment
+
 AndroidStudio & JUnit4
-### 9.3	Productivity and Support Tools
+
+### 9.3 Productivity and Support Tools
+
 n/a
+
 ### 9.4 Test Environment Configurations
+
 n/a
-## 10.	Responsibilities, Staffing, and Training Needs
-### 10.1	People and Roles
+
+## 10. Responsibilities, Staffing, and Training Needs
+
+### 10.1 People and Roles
+
 This table shows the staffing assumptions for the test effort.
 
 Human Resources
 
-| Role | Minimum Resources Recommended (number of full-time roles allocated) |	Specific Responsibilities or Comments |
+| Role | Minimum Resources Recommended (number of full-time roles allocated) | Specific Responsibilities or Comments |
 |---|---|---|
 | Test Manager | 1 | Provides management oversight. <br> Responsibilities include: <br> planning and logistics <br> agree mission <br> identify motivators<br> acquire appropriate resources<br> present management reporting<br> advocate the interests of test<br>evaluate effectiveness of test effort |
 | Test Designer | 1 | Defines the technical approach to the implementation of the test effort. <br> Responsibilities include:<br> define test approach<br> define test automation architecture<br> verify test techniques<br> define testability elements<br> structure test implementation|
-| Tester | 1 |	Implements and executes the tests.<br> Responsibilities include:<br> implement tests and test suites<br> execute test suites<br> log results<br> analyze and recover from test failures<br> document incidents|
-| Test System Administrator | 1 | Ensures test environment and assets are managed and maintained.<br> Responsibilities include:<br> 	administer test management system<br> install and support access to, and recovery of, test environment configurations and test labs | 
+| Tester | 1 | Implements and executes the tests.<br> Responsibilities include:<br> implement tests and test suites<br> execute test suites<br> log results<br> analyze and recover from test failures<br> document incidents|
+| Test System Administrator | 1 | Ensures test environment and assets are managed and maintained.<br> Responsibilities include:<br>  administer test management system<br> install and support access to, and recovery of, test environment configurations and test labs |
 | Implementer | 3| Implements and unit tests the test classes and test packages.<br> Responsibilities include:<br> creates the test components required to support testability requirements as defined by the designer |
-### 10.2	Staffing and Training Needs
+
+### 10.2 Staffing and Training Needs
+
 tbd
-## 11.	Iteration Milestones
+
+## 11. Iteration Milestones
+
 n/a
+
 ## 12. Risks, Dependencies, Assumptions, and Constrains
+
 n/a
+
 ## 13. Management, Process and Procedures
+
 ### 13.1 Measuring and Assessing the Extent of Testing
-Test-Coverage is evaluated by sonarcloud though testreports delivered by jacoco running on travis ci
+
+Test-Coverage is evaluated by sonarcloud though test reports delivered by jacoco running on travis ci
+
 ### 13.2 Assessing the Deliverables of this Test Plan
+
 n/a
+
 ### 13.3 Problem Reporting, Escalation, and Issue Resolution
-At the moment the only issues being tackled are the ones reported here though GitHub and automaticaly analysed by sonarcloud
+
+At the moment the only issues being tackled are the ones reported here though GitHub and automatically
+analysed by sonarcloud
+
 ### 13.4 Managing Test Cycles
+
 Testing is automated. On every commit to GitHub a build and test process is started using travis ci
+
 ### 13.5 Traceability Strategies
+
 n/a
+
 ### 13.6 Approval and Signoff
+
 n/a


### PR DESCRIPTION
Markdown doesn't care about tabs and it's considered clean to leave spaces around headings and lists.
I didn't remove the html anchors, as I assume you have a reason for putting them (GitHub does support linking to headings though, by default https://gist.github.com/asabaylus/3071099 )